### PR TITLE
Task 213 - Implement Lab Result Upload API

### DIFF
--- a/HealthCareHub/src/main/java/nimblix/in/HealthCareHub/controller/LabResultController.java
+++ b/HealthCareHub/src/main/java/nimblix/in/HealthCareHub/controller/LabResultController.java
@@ -1,0 +1,19 @@
+package nimblix.in.HealthCareHub.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import nimblix.in.HealthCareHub.model.LabResult;
+import nimblix.in.HealthCareHub.service.LabResultService;
+
+@RestController
+@RequestMapping("/api/lab-results")
+@RequiredArgsConstructor
+public class LabResultController {
+
+    private final LabResultService labResultService;
+
+    @PostMapping("/upload")
+    public LabResult uploadLabResult(@RequestBody LabResult labResult) {
+        return labResultService.uploadLabResult(labResult);
+    }
+}

--- a/HealthCareHub/src/main/java/nimblix/in/HealthCareHub/model/LabResult.java
+++ b/HealthCareHub/src/main/java/nimblix/in/HealthCareHub/model/LabResult.java
@@ -1,0 +1,26 @@
+package nimblix.in.HealthCareHub.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LabResult {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String testName;
+
+    private String resultValue;
+
+    private String status;
+
+    private LocalDateTime uploadedAt;
+}

--- a/HealthCareHub/src/main/java/nimblix/in/HealthCareHub/repository/LabResultRepository.java
+++ b/HealthCareHub/src/main/java/nimblix/in/HealthCareHub/repository/LabResultRepository.java
@@ -1,0 +1,7 @@
+package nimblix.in.HealthCareHub.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import nimblix.in.HealthCareHub.model.LabResult;
+
+public interface LabResultRepository extends JpaRepository<LabResult, Long> {
+}

--- a/HealthCareHub/src/main/java/nimblix/in/HealthCareHub/service/LabResultService.java
+++ b/HealthCareHub/src/main/java/nimblix/in/HealthCareHub/service/LabResultService.java
@@ -1,0 +1,8 @@
+package nimblix.in.HealthCareHub.service;
+
+import nimblix.in.HealthCareHub.model.LabResult;
+
+public interface LabResultService {
+
+    LabResult uploadLabResult(LabResult labResult);
+}

--- a/HealthCareHub/src/main/java/nimblix/in/HealthCareHub/serviceImpl/LabResultServiceImpl.java
+++ b/HealthCareHub/src/main/java/nimblix/in/HealthCareHub/serviceImpl/LabResultServiceImpl.java
@@ -1,0 +1,22 @@
+package nimblix.in.HealthCareHub.serviceImpl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import nimblix.in.HealthCareHub.model.LabResult;
+import nimblix.in.HealthCareHub.repository.LabResultRepository;
+import nimblix.in.HealthCareHub.service.LabResultService;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class LabResultServiceImpl implements LabResultService {
+
+    private final LabResultRepository labResultRepository;
+
+    @Override
+    public LabResult uploadLabResult(LabResult labResult) {
+        labResult.setUploadedAt(LocalDateTime.now());
+        return labResultRepository.save(labResult);
+    }
+}


### PR DESCRIPTION
Implemented Lab Result Upload API (Task 213)

Changes:
- Created LabResult entity
- Created LabResultRepository
- Created LabResultService interface
- Created LabResultServiceImpl
- Created LabResultController
- Configured database connection for local profile

API Endpoint:
POST /api/lab-results/upload

Tested successfully using Postman.
Response returns saved lab result with ID and uploaded timestamp.
